### PR TITLE
Evals refactor

### DIFF
--- a/jaxgmg/cli/train.py
+++ b/jaxgmg/cli/train.py
@@ -37,8 +37,10 @@ def corner(
     num_parallel_envs: int = 32,
     fixed_train_levels: bool = False,
     num_train_levels: int = 2048,
-    # other
-    seed: int = 42,
+    # training animation dimensions
+    train_gifs: bool = True,
+    train_gif_grid_width: int = 8,
+    train_gif_level_of_detail: int = 1,
     # evals config
     num_cycles_per_eval: int = 64,
     num_eval_levels: int = 256,
@@ -61,6 +63,8 @@ def corner(
     keep_all_checkpoints: bool = False,     # if so: keep all of them? (no)
     max_num_checkpoints: int = 1,           # if not: keep only latest n (=1)
     num_cycles_per_checkpoint: int = 512,
+    # other
+    seed: int = 42,
 ):
     util.print_config(locals())
 
@@ -119,6 +123,7 @@ def corner(
         benchmarks=eval_on_benchmark_returns,
         num_steps=num_env_steps_per_eval,
         discount_rate=ppo_gamma,
+        env=env,
     )
 
     # off distribution
@@ -139,10 +144,11 @@ def corner(
     )
     eval_off_level_set = ppo.FixedLevelsEval(
         num_levels=num_eval_levels,
-        levels=eval_off_levels,
-        benchmarks=eval_off_benchmark_returns,
         num_steps=num_env_steps_per_eval,
         discount_rate=ppo_gamma,
+        levels=eval_off_levels,
+        benchmarks=eval_off_benchmark_returns,
+        env=env,
     )
     
     # gif animations from those levels
@@ -152,6 +158,7 @@ def corner(
         num_steps=env.max_steps_in_episode,
         gif_grid_width=eval_gif_grid_width,
         gif_level_of_detail=eval_gif_level_of_detail,
+        env=env,
     )
     eval_off_animation = ppo.AnimatedRolloutsEval(
         num_levels=num_eval_levels,
@@ -159,6 +166,7 @@ def corner(
         num_steps=env.max_steps_in_episode,
         gif_grid_width=eval_gif_grid_width,
         gif_level_of_detail=eval_gif_level_of_detail,
+        env=env,
     )
 
     # splayed eval levels
@@ -171,26 +179,29 @@ def corner(
             splay = cheese_in_the_corner.splay_cheese_and_mouse 
         case _:
             raise ValueError(f'unknown level splayer {level_splayer!r}')
-    # TODO: refactor to be explicit about this bit
     eval_on_heatmap_0 = ppo.HeatmapVisualisationEval(
         *splay(jax.tree.map(lambda x: x[0], eval_on_levels)),
         num_steps=num_env_steps_per_eval,
         discount_rate=ppo_gamma,
+        env=env,
     )
     eval_on_heatmap_1 = ppo.HeatmapVisualisationEval(
         *splay(jax.tree.map(lambda x: x[1], eval_on_levels)),
         num_steps=num_env_steps_per_eval,
         discount_rate=ppo_gamma,
+        env=env,
     )
     eval_off_heatmap_0 = ppo.HeatmapVisualisationEval(
         *splay(jax.tree.map(lambda x: x[0], eval_off_levels)),
         num_steps=num_env_steps_per_eval,
         discount_rate=ppo_gamma,
+        env=env,
     )
     eval_off_heatmap_1 = ppo.HeatmapVisualisationEval(
         *splay(jax.tree.map(lambda x: x[1], eval_off_levels)),
         num_steps=num_env_steps_per_eval,
         discount_rate=ppo_gamma,
+        env=env,
     )
 
     ppo.run(
@@ -227,6 +238,10 @@ def corner(
         num_total_env_steps=num_total_env_steps,
         num_env_steps_per_cycle=num_env_steps_per_cycle,
         num_parallel_envs=num_parallel_envs,
+        # training animation dimensions
+        train_gifs=train_gifs,
+        train_gif_grid_width=train_gif_grid_width,
+        train_gif_level_of_detail=train_gif_level_of_detail,
         # evals
         num_cycles_per_eval=num_cycles_per_eval,
         num_cycles_per_big_eval=num_cycles_per_big_eval,

--- a/jaxgmg/cli/train.py
+++ b/jaxgmg/cli/train.py
@@ -6,11 +6,6 @@ import jax
 
 from jaxgmg.procgen import maze_generation
 from jaxgmg.environments import cheese_in_the_corner
-from jaxgmg.environments import cheese_on_a_dish
-# from jaxgmg.environments import keys_and_chests
-# from jaxgmg.environments import monster_world
-from jaxgmg.environments import lava_land
-# from jaxgmg.environments import follow_me
 from jaxgmg.baselines import ppo
 
 from jaxgmg import util
@@ -22,12 +17,12 @@ def corner(
     env_size: int = 9,
     env_layout: str = 'blocks',
     env_corner_size: int = 1,
-    env_level_of_detail: int = 0,       # 0 = bool; 1, 3, 4, or 8 = rgb
+    env_level_of_detail: int = 0,           # 0 = bool; 1, 3, 4, or 8 = rgb
     # policy config
     net: str = "relu",
     # PPO hyperparameters
-    ppo_lr: float = 0.0005,             # learning rate
-    ppo_gamma: float = 0.999,           # discount rate
+    ppo_lr: float = 0.0005,                 # learning rate
+    ppo_gamma: float = 0.999,               # discount rate
     ppo_clip_eps: float = 0.2,
     ppo_gae_lambda: float = 0.95,
     ppo_entropy_coeff: float = 0.001,
@@ -40,37 +35,32 @@ def corner(
     num_total_env_steps: int = 20_000_000,
     num_env_steps_per_cycle: int = 256,
     num_parallel_envs: int = 32,
+    fixed_train_levels: bool = False,
     num_train_levels: int = 2048,
-    # evaluation dimensions
+    # other
+    seed: int = 42,
+    # evals config
     num_cycles_per_eval: int = 64,
     num_eval_levels: int = 256,
     num_env_steps_per_eval: int = 512,
-    level_splayer: str = 'mouse',       # or 'cheese' or 'cheese-and-mouse'
+    # big evals config
+    num_cycles_per_big_eval: int = 1024,    # roughly 9M env steps
+    eval_gif_grid_width: int = 16,
+    eval_gif_level_of_detail: int = 1,      # 1, 3, 4 or 8
+    level_splayer: str = 'mouse',           # or 'cheese' or 'cheese-and-mouse'
     # logging
-    console_log: bool = True,           # whether to log metrics to stdout
     num_cycles_per_log: int = 64,
-    # wandb logging (forwarded to wandb by the wrapper)
-    wandb_log: bool = False,            # whether to log metrics to wandb
+    save_files_to: str = "logs/",
+    console_log: bool = True,               # whether to log metrics to stdout
+    wandb_log: bool = False,                # whether to log metrics to wandb
     wandb_project: str = "test",
     wandb_group: str = None,
     wandb_name: str = None,
-    # gif animations for training/eval rollouts
-    train_gifs: bool = True,
-    eval_gifs: bool = True,
-    num_cycles_per_gif: int = 1024, # roughly 9M
-    gif_grid_width: int = 16,
-    gif_level_of_detail: int = 1,       # 1, 3, 4 or 8
-    # splay rate (these are kinda slow)
-    num_cycles_per_splay: int = 1024,
-    # output save directory
-    save_files_to: str = "logs/",
     # checkpointing
-    checkpointing: bool = True,             # default: keep checkpoints?    y
-    keep_all_checkpoints: bool = False,     # if not: keep all checkpoints? n
-    max_num_checkpoints: int = 1,           # if not: keep only this many
+    checkpointing: bool = True,             # keep checkpoints? (default: yes)
+    keep_all_checkpoints: bool = False,     # if so: keep all of them? (no)
+    max_num_checkpoints: int = 1,           # if not: keep only latest n (=1)
     num_cycles_per_checkpoint: int = 512,
-    # other
-    seed: int = 42,
 ):
     util.print_config(locals())
 
@@ -83,7 +73,7 @@ def corner(
         penalize_time=False,
     )
 
-    print(f"generating {num_train_levels} training levels...")
+    print(f"generating training level distribution...")
     maze_generator = maze_generation.get_generator_class_from_name(
         name=env_layout,
     )()
@@ -94,19 +84,44 @@ def corner(
         corner_size=env_corner_size,
     )
     rng_train_levels, rng_setup = jax.random.split(rng_setup)
-    train_levels = train_level_generator.vsample(
-        rng_train_levels,
-        num_levels=num_train_levels,
+    if fixed_train_levels:
+        train_levels = train_level_generator.vsample(
+            rng_train_levels,
+            num_levels=num_train_levels,
+        )
+        train_level_set = ppo.FixedTrainLevelSet(
+            num_levels=num_train_levels,
+            levels=train_levels,
+        )
+    else:
+        train_level_set = ppo.OnDemandTrainLevelSet(
+            level_generator=train_level_generator,
+        )
+
+    print(f"generating some eval levels with baselines...")
+    level_solver = cheese_in_the_corner.LevelSolver(
+        env=env,
+        discount_rate=ppo_gamma,
     )
-    
-    print(f"generating {num_eval_levels} on-distribution eval levels...")
+    # on distribution
     rng_eval_on_levels, rng_setup = jax.random.split(rng_setup)
     eval_on_levels = train_level_generator.vsample(
         rng_eval_on_levels,
         num_levels=num_eval_levels,
     )
-    
-    print(f"generating {num_eval_levels} off-distribution eval levels...")
+    eval_on_benchmark_returns = level_solver.vmap_level_value(
+        level_solver.vmap_solve(eval_on_levels),
+        eval_on_levels,
+    )
+    eval_on_level_set = ppo.FixedLevelsEval(
+        num_levels=num_eval_levels,
+        levels=eval_on_levels,
+        benchmarks=eval_on_benchmark_returns,
+        num_steps=num_env_steps_per_eval,
+        discount_rate=ppo_gamma,
+    )
+
+    # off distribution
     shift_level_generator = cheese_in_the_corner.LevelGenerator(
         height=env_size,
         width=env_size,
@@ -118,65 +133,82 @@ def corner(
         rng_eval_off_levels,
         num_levels=num_eval_levels,
     )
-
-    print("solving levels to get benchmark returns...")
-    level_solver = cheese_in_the_corner.LevelSolver(
-        env=env,
-        discount_rate=ppo_gamma,
-    )
-    train_benchmark_returns = level_solver.vmap_level_value(
-        level_solver.vmap_solve(train_levels),
-        train_levels,
-    )
-    eval_on_benchmark_returns = level_solver.vmap_level_value(
-        level_solver.vmap_solve(eval_on_levels),
-        eval_on_levels,
-    )
     eval_off_benchmark_returns = level_solver.vmap_level_value(
         level_solver.vmap_solve(eval_off_levels),
         eval_off_levels,
     )
-
-    print("generating splayed eval batches...")
-    LevelSplayer = cheese_in_the_corner.LevelSplayer
-    match level_splayer:
-        case 'mouse':
-            splay = LevelSplayer.splay_mouse
-        case 'cheese':
-            splay = LevelSplayer.splay_cheese
-        case 'cheese-and-mouse':
-            splay = LevelSplayer.splay_cheese_and_mouse 
-        case _:
-            raise ValueError(f'unknown level splayer {level_splayer!r}')
-    train_splayset = splay(jax.tree.map(lambda x: x[0], train_levels))
-    eval_on_splayset = splay(jax.tree.map(lambda x: x[0], eval_on_levels))
-    eval_off_splayset = splay(jax.tree.map(lambda x: x[0], eval_off_levels))
-    print(
-        "  num levels:",
-        train_splayset.num_levels,
-        eval_on_splayset.num_levels,
-        eval_off_splayset.num_levels,
+    eval_off_level_set = ppo.FixedLevelsEval(
+        num_levels=num_eval_levels,
+        levels=eval_off_levels,
+        benchmarks=eval_off_benchmark_returns,
+        num_steps=num_env_steps_per_eval,
+        discount_rate=ppo_gamma,
+    )
+    
+    # gif animations from those levels
+    eval_on_animation = ppo.AnimatedRolloutsEval(
+        num_levels=num_eval_levels,
+        levels=eval_on_levels,
+        num_steps=env.max_steps_in_episode,
+        gif_grid_width=eval_gif_grid_width,
+        gif_level_of_detail=eval_gif_level_of_detail,
+    )
+    eval_off_animation = ppo.AnimatedRolloutsEval(
+        num_levels=num_eval_levels,
+        levels=eval_off_levels,
+        num_steps=env.max_steps_in_episode,
+        gif_grid_width=eval_gif_grid_width,
+        gif_level_of_detail=eval_gif_level_of_detail,
     )
 
+    # splayed eval levels
+    match level_splayer:
+        case 'mouse':
+            splay = cheese_in_the_corner.splay_mouse
+        case 'cheese':
+            splay = cheese_in_the_corner.splay_cheese
+        case 'cheese-and-mouse':
+            splay = cheese_in_the_corner.splay_cheese_and_mouse 
+        case _:
+            raise ValueError(f'unknown level splayer {level_splayer!r}')
+    # TODO: refactor to be explicit about this bit
+    eval_on_heatmap_0 = ppo.HeatmapVisualisationEval(
+        *splay(jax.tree.map(lambda x: x[0], eval_on_levels)),
+        num_steps=num_env_steps_per_eval,
+        discount_rate=ppo_gamma,
+    )
+    eval_on_heatmap_1 = ppo.HeatmapVisualisationEval(
+        *splay(jax.tree.map(lambda x: x[1], eval_on_levels)),
+        num_steps=num_env_steps_per_eval,
+        discount_rate=ppo_gamma,
+    )
+    eval_off_heatmap_0 = ppo.HeatmapVisualisationEval(
+        *splay(jax.tree.map(lambda x: x[0], eval_off_levels)),
+        num_steps=num_env_steps_per_eval,
+        discount_rate=ppo_gamma,
+    )
+    eval_off_heatmap_1 = ppo.HeatmapVisualisationEval(
+        *splay(jax.tree.map(lambda x: x[1], eval_off_levels)),
+        num_steps=num_env_steps_per_eval,
+        discount_rate=ppo_gamma,
+    )
 
     ppo.run(
         rng=rng_train,
         # environment and level distributions
         env=env,
-        train_levels=train_levels,
-        eval_levels_dict={
-            'on-distribution': eval_on_levels,
-            'off-distribution': eval_off_levels,
+        train_level_set=train_level_set,
+        evals_dict={
+            'on_distribution': eval_on_level_set,
+            'off_distribution': eval_off_level_set,
         },
-        train_benchmark_returns=train_benchmark_returns,
-        eval_benchmark_returns_dict={
-            'on-distribution': eval_on_benchmark_returns,
-            'off-distribution': eval_off_benchmark_returns,
-        },
-        splayset_dict={
-            'train-level-0': train_splayset,
-            'eval-on-level-0': eval_on_splayset,
-            'eval-off-level-0': eval_off_splayset,
+        big_evals_dict={
+            'on_distribution_animations': eval_on_animation,
+            'off_distribution_animations': eval_off_animation,
+            'on_distribution_level_0_heatmaps': eval_on_heatmap_0,
+            'on_distribution_level_1_heatmaps': eval_on_heatmap_1,
+            'off_distribution_eval_level_0_heatmaps': eval_off_heatmap_0,
+            'off_distribution_eval_level_1_heatmaps': eval_off_heatmap_1,
         },
         # architecture
         net=net,
@@ -191,27 +223,23 @@ def corner(
         ppo_lr_annealing=ppo_lr_annealing,
         num_minibatches_per_epoch=num_minibatches_per_epoch,
         num_epochs_per_cycle=num_epochs_per_cycle,
+        # training dimensions
         num_total_env_steps=num_total_env_steps,
         num_env_steps_per_cycle=num_env_steps_per_cycle,
         num_parallel_envs=num_parallel_envs,
+        # evals
         num_cycles_per_eval=num_cycles_per_eval,
-        num_env_steps_per_eval=num_env_steps_per_eval,
+        num_cycles_per_big_eval=num_cycles_per_big_eval,
+        # logging
+        num_cycles_per_log=num_cycles_per_log,
+        save_files_to=save_files_to,
+        console_log=console_log,
+        wandb_log=wandb_log,
         # checkpointing
         checkpointing=checkpointing,
         keep_all_checkpoints=keep_all_checkpoints,
         max_num_checkpoints=max_num_checkpoints,
         num_cycles_per_checkpoint=num_cycles_per_checkpoint,
-        # logging
-        console_log=console_log,
-        wandb_log=wandb_log,
-        num_cycles_per_log=num_cycles_per_log,
-        train_gifs=train_gifs,
-        eval_gifs=eval_gifs,
-        num_cycles_per_gif=num_cycles_per_gif,
-        gif_grid_width=gif_grid_width,
-        gif_level_of_detail=gif_level_of_detail,
-        num_cycles_per_splay=num_cycles_per_splay,
-        save_files_to=save_files_to,
     )
     # (the decorator finishes the wandb run for us, so no need to do that)
     print("training run complete.")

--- a/jaxgmg/environments/base.py
+++ b/jaxgmg/environments/base.py
@@ -417,11 +417,3 @@ class LevelSolver:
         return vectorised_level_value(solns, levels)
 
 
-@struct.dataclass
-class SplayedLevelSet:
-    levels: Level
-    num_levels: int
-    levels_pos: Tuple[chex.Array, chex.Array]
-    grid_shape: Tuple[int, int]
-
-

--- a/jaxgmg/util.py
+++ b/jaxgmg/util.py
@@ -70,7 +70,7 @@ def dict2str(dct):
         else:
             return str(value)
     return '\n'.join([
-        '  '*depth + (key + ':').ljust(42-2*depth) + render(value)
+        '  '*depth + (key + ':').ljust(48-2*depth) + render(value)
         for depth, key, value in dict2lines(dct, 1)
     ])
 
@@ -260,22 +260,6 @@ def wandb_gif(frames, fps=12):
         ),
         fps=fps,
     )
-
-
-def wandb_metrics_dict(metrics):
-    """
-    take a nested / typed metrics dict and convert it into a format
-    wandb will be able to handle
-    """
-    metrics_flat = flatten_dict(metrics)
-    for key, val in metrics_flat.items():
-        if key.endswith("_hist"):
-            metrics_flat[key] = wandb.Histogram(val)
-        if key.endswith("_gif"):
-            metrics_flat[key] = wandb_gif(val)
-        if key.endswith("_img"):
-            metrics_flat[key] = wandb_image(val)
-    return metrics_flat
 
 
 # # # 


### PR DESCRIPTION
refactoring the run script as follows:

* modifications to the command line interface of `jaxgmg train corner`
  * in particular, slight modifications to the way evals and heatmaps and logging are configured
  * notably, added an option `--fixed-train-levels` (default: `--no-fixed-train-levels`, meaning levels are generated fresh each training cycle)
  * changed some defaults to encourage logging more stuff by default, particularly training gifs
* simplified the interface to `jaxgmg.baselines.ppo.run` function
  * in particular, different types of evals (rollouts in fixed eval levels, gifs in fixed eval levels, heatmaps) are unified into two dictionaries of `Eval` structs (one for frequent cheap evals, one for infrequent expensive evals), each struct contains the configuration for the eval, the supported evals are defined in `ppo.py`.
  * similarly for training levels using `TrainingLevelSet` structs defined in `ppo.py`.
* simplified the internal structure of the `ppo.run` function with respect to logging and made it more comprehensive
  * all metrics, histograms, etc. are logged to disk by default
  * specialised code for different evals not out of main loop and abstracted into `Eval` classes